### PR TITLE
[bugfix] remove yaplakal.com from domain blacklist

### DIFF
--- a/app/src/main/res/values/blocked_domains.xml
+++ b/app/src/main/res/values/blocked_domains.xml
@@ -2122,7 +2122,6 @@
         <item>yangofellowship.com</item>
         <item>yap.ru</item>
         <item>yapfiles.ru</item>
-        <item>yaplakal.com</item>
         <item>yaroslavl.ru</item>
         <item>yastat.net</item>
         <item>yastatic-net.ru</item>


### PR DESCRIPTION
Removed 'yaplakal.com' from the blocked domains list.